### PR TITLE
Fix labels for Maven 3.8.x

### DIFF
--- a/vars/jenkinsEnv.groovy
+++ b/vars/jenkinsEnv.groovy
@@ -74,7 +74,7 @@ class jenkinsEnv implements Serializable {
                     case ~/^3\.6\.[x3]$/:
                         return 'maven_3.6.3'
                     case ~/^3\.8\.x$/:
-                        return 'maven_3_latest'
+                        return 'maven_3.8.6'
                     case '3.x.x':
                         return 'maven_3_latest'
                     default:
@@ -95,7 +95,7 @@ class jenkinsEnv implements Serializable {
                     case ~/^3\.6\.[x4]$/:
                         return 'maven_3.6.3_windows'
                     case ~/^3\.8\.x$/:
-                        return 'maven_3_latest'
+                        return 'maven_3.8.6_windows'
                     case '3.x.x':
                         return 'maven_3_latest'
                     default:


### PR DESCRIPTION
`maven_3_latest` - points to `3.9.6`, for `3.8.x` we should use dedicated label

According to documentation: 
https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Maven+Installation+Matrix
`3.8.6` is the latest version of `3.8.x` installed on all environments.
